### PR TITLE
init Thread.current[:request_store] with {} in the tests

### DIFF
--- a/test/request_store_test.rb
+++ b/test/request_store_test.rb
@@ -4,12 +4,14 @@ require 'request_store'
 
 class RequestStoreTest < Minitest::Unit::TestCase
   def test_quacks_like_hash
+    Thread.current[:request_store] = {}
     RequestStore.store[:foo] = 1
     assert_equal 1, RequestStore.store[:foo]
     assert_equal 1, RequestStore.store.fetch(:foo)
   end
 
   def test_delegates_to_thread
+    Thread.current[:request_store] = {}
     RequestStore.store[:foo] = 1
     assert_equal 1, Thread.current[:request_store][:foo]
   end


### PR DESCRIPTION
there is a problem with the RequestStoreTest tests currently, they only runs while the MiddlewareTest exec bevor, so the MiddlewareTest init Thread.current[:request_store]

The current execution order is:
1. test_middleware_resets_store
2. test_quacks_like_hash
3. test_delegates_to_thread
