### PR TITLE
Allow RequestStore to be usable when the middleware is not inserted/enabled

### DIFF
--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -4,7 +4,7 @@ require "request_store/railtie" if defined?(Rails)
 
 module RequestStore
   def self.store
-    Thread.current[:request_store]
+    Thread.current[:request_store] ||= {}
   end
 
   def self.clear!

--- a/test/request_store_test.rb
+++ b/test/request_store_test.rb
@@ -3,6 +3,11 @@ require 'minitest/autorun'
 require 'request_store'
 
 class RequestStoreTest < Minitest::Unit::TestCase
+  def test_initial_state
+    Thread.current[:request_store] = nil
+    assert_equal RequestStore.store, Hash.new
+  end
+
   def test_init_with_hash
     RequestStore.clear!
     assert_equal Hash.new, RequestStore.store


### PR DESCRIPTION
Fixes an issue when using RequestStore in rake tasks/tests etc:

1.9.3p125 :002 > RequestStore.store[:my_var]
NoMethodError: undefined method `[]' for nil:NilClass
    from (irb):2
