### PR TITLE
Initialize store for use without middleware

### DIFF
--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -11,3 +11,5 @@ module RequestStore
     Thread.current[:request_store] = {}
   end
 end
+
+RequestStore.clear!


### PR DESCRIPTION
Using RequestStore without middleware happens at the console or in tests. Assuming that these are usually single-threaded environments, this might be the simplest possible way of initializing the store.
