### PR TITLE
Don't require Railstie unless using Rails 3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,19 @@ Yep, everywhere you used `Thread.current` just change it to
 `RequestStore.store`. Now no matter what server you use, you'll get `1` every
 time: the storage is local to that request.
 
+### Rails 2 compatibility
+
+The gem includes a Railtie that will configure everything properly for Rails 3+
+apps, but if your app is tied to an older (2.x) version, you will have to
+manually add the middleware yourself.  Typically this should just be a matter
+of adding:
+
+```
+config.middleware.use RequestStore::Middleware
+```
+
+into your config/environment.rb.
+
 ### No Rails? No Problem!
 
 A Railtie is added that configures the Middleware for you, but if you're not

--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -1,6 +1,6 @@
 require "request_store/version"
 require "request_store/middleware"
-require "request_store/railtie" if defined?(Rails)
+require "request_store/railtie" if defined?(Rails) && Rails.version.to_i > 2
 
 module RequestStore
   def self.store

--- a/lib/request_store/version.rb
+++ b/lib/request_store/version.rb
@@ -1,3 +1,3 @@
 module RequestStore
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end


### PR DESCRIPTION
To allow using the gem if your app is tied to a version of Rails older
than 3, this commit makes the require of the Railstie conditional on the
version string.

Initially I had a the conditional require using a regex on the version string,
but then switched to doing a numerical comparison.

Added paragraph into README regarding Rails 2 compatibility.

Also cheekily bumped version to 1.0.4.
