### PR TITLE
Insert RequestStore::Middleware earlier in the stack

### DIFF
--- a/lib/request_store/railtie.rb
+++ b/lib/request_store/railtie.rb
@@ -1,7 +1,7 @@
 module RequestStore
   class Railtie < ::Rails::Railtie
     initializer "request_store.insert_middleware" do |app|
-      app.config.middleware.use RequestStore::Middleware
+      app.config.middleware.insert_after Rack::MethodOverride, RequestStore::Middleware
     end
   end
 end


### PR DESCRIPTION
This will allow other middlewares to use it as well.
