### PR TITLE
Add convenience methods to mimic Rails.cache interface

### DIFF
--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -3,11 +3,36 @@ require "request_store/middleware"
 require "request_store/railtie" if defined?(Rails::Railtie)
 
 module RequestStore
-  def self.store
-    Thread.current[:request_store] ||= {}
-  end
+	def self.store
+		Thread.current[:request_store] ||= {}
+	end
 
-  def self.clear!
-    Thread.current[:request_store] = {}
-  end
+	def self.clear!
+		Thread.current[:request_store] = {}
+	end
+
+	def self.read(key)
+		store[key]
+	end
+
+	def self.[](key)
+		store[key]
+	end
+
+	def self.write(key, value)
+		store[key] = value
+	end
+
+	def self.[]=(key, value)
+		store[key] = value
+	end
+
+	def self.exist?(key)
+		store.key?(key)
+	end
+
+	def self.fetch(key, &block)
+		store[key] = yield unless exist?(key)
+		store[key]
+	end
 end

--- a/test/request_store_test.rb
+++ b/test/request_store_test.rb
@@ -27,6 +27,27 @@ class RequestStoreTest < Minitest::Unit::TestCase
     assert_equal 1, RequestStore.store.fetch(:foo)
   end
 
+  def test_read
+    RequestStore.clear!
+    RequestStore.store[:foo] = 1
+    assert_equal 1, RequestStore.read(:foo)
+    assert_equal 1, RequestStore[:foo]
+  end
+
+  def test_write
+    RequestStore.clear!
+    RequestStore.write(:foo, 1)
+    assert_equal 1, RequestStore.store[:foo]
+    RequestStore[:foo] = 2
+    assert_equal 2, RequestStore.store[:foo]
+  end
+
+  def test_fetch
+    RequestStore.clear!
+    assert_equal 2, RequestStore.fetch(:foo) { 1 + 1 }
+    assert_equal 2, RequestStore.fetch(:foo) { 2 + 2 }
+  end
+
   def test_delegates_to_thread
     RequestStore.clear!
     RequestStore.store[:foo] = 1


### PR DESCRIPTION
Fixing up the style: I hate `class << self`.
