### PR TITLE
Insert middleware after ActionDispatch::RequestId

### DIFF
--- a/lib/request_store/railtie.rb
+++ b/lib/request_store/railtie.rb
@@ -1,7 +1,7 @@
 module RequestStore
   class Railtie < ::Rails::Railtie
     initializer "request_store.insert_middleware" do |app|
-      app.config.middleware.insert_after Rack::MethodOverride, RequestStore::Middleware
+      app.config.middleware.insert_after ActionDispatch::RequestId, RequestStore::Middleware
     end
   end
 end


### PR DESCRIPTION
When using rails-api with api_only set to true, Rack::MethodOverride is not included in the middleware stack. ActionDispatch::RequestId follows Rack::MethodOverride in rails-api and the normal rails middleware stacks so inserting after that instead.

Resolves #27
