### PR TITLE
Rails console's #reload! now clears RequestStore

### DIFF
--- a/lib/request_store/railtie.rb
+++ b/lib/request_store/railtie.rb
@@ -6,6 +6,12 @@ module RequestStore
       else
         app.config.middleware.insert_after Rack::MethodOverride, RequestStore::Middleware
       end
+
+      if ActionDispatch.const_defined?(:Reloader) && ActionDispatch::Reloader.respond_to?(:to_cleanup)
+        ActionDispatch::Reloader.to_cleanup do
+          RequestStore.clear!
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
By registering to ActionDispatch::Reloader, we make the #reload! method in a rails console clear the RequestStore, solving possible issues where instances of old classes remain, and also just logically make a #reload! more complete.

The callback is also called after every requests in development (when config.cache_classes is false), but considering how light RequestStore::clear! is, and that this is only in dev, that's a non-issue.