### PR TITLE
Fix minitest warning with an additional 'require'.

### DIFF
--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -1,3 +1,4 @@
+require 'minitest/test'
 require 'minitest/autorun'
 
 require 'request_store'


### PR DESCRIPTION
Running the test suite out-of-the-box throws a warning, although the
test suite still passes:

```
$ rake
...
Warning: you should require 'minitest/autorun' instead.
Warning: or add 'gem "minitest"' before 'require "minitest/autorun"'
...
$ echo $?
0
```

If we add an additional "require" to `test/middleware_test.rb`,

```ruby
require 'minitest/test'
```

the warning goes away and the test suite still passes:
```
$ rake
...
# Running:

...........

Finished in 0.001800s, 6110.1165 runs/s, 11109.3028 assertions/s.

11 runs, 20 assertions, 0 failures, 0 errors, 0 skips
```