### PR TITLE
Adding MIT license to the gemspec.

### DIFF
--- a/request_store.gemspec
+++ b/request_store.gemspec
@@ -11,6 +11,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{RequestStore gives you per-request global storage.}
   gem.summary       = %q{RequestStore gives you per-request global storage.}
   gem.homepage      = "http://github.com/steveklabnik/request_store"
+  gem.licenses      = ["MIT"]
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
I'm working on [VersionEye](https://www.versioneye.com/) and I have the goal to build up a license db for RubyGems which is complete. To reduce the manual work I'm doing currently it would be awesome if this gemspec would contain the license information in future. Many Thanks. 