### PR TITLE
Ability to determine if your code is running within the context of a request

### DIFF
--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -11,6 +11,18 @@ module RequestStore
     Thread.current[:request_store] = {}
   end
 
+  def self.begin!
+    Thread.current[:request_store_active] = true
+  end
+
+  def self.end!
+    Thread.current[:request_store_active] = false
+  end
+
+  def self.active?
+    Thread.current[:request_store_active] || false
+  end
+
   def self.read(key)
     store[key]
   end

--- a/lib/request_store/middleware.rb
+++ b/lib/request_store/middleware.rb
@@ -5,8 +5,10 @@ module RequestStore
     end
 
     def call(env)
+      RequestStore.begin!
       @app.call(env)
     ensure
+      RequestStore.end!
       RequestStore.clear!
     end
   end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -24,4 +24,22 @@ class MiddlewareTest < Minitest::Test
     assert_equal 'FAIL', e.message
     assert_equal({}, RequestStore.store)
   end
+
+  def test_middleware_begins_store
+    @middleware.call({})
+    assert_equal true, @app.store_active
+  end
+
+  def test_middleware_ends_store
+    @middleware.call({})
+    assert_equal false, RequestStore.active?
+  end
+
+  def test_middleware_ends_store_on_error
+    assert_raises RuntimeError do
+      @middleware.call({:error => true})
+    end
+
+    assert_equal false, RequestStore.active?
+  end
 end

--- a/test/request_store_test.rb
+++ b/test/request_store_test.rb
@@ -56,4 +56,14 @@ class RequestStoreTest < Minitest::Test
     RequestStore.store[:foo] = 1
     assert_equal 1, Thread.current[:request_store][:foo]
   end
+
+  def test_active_state
+    assert_equal false, RequestStore.active?
+
+    RequestStore.begin!
+    assert_equal true, RequestStore.active?
+
+    RequestStore.end!
+    assert_equal false, RequestStore.active?
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,10 +1,11 @@
 class RackApp
-  attr_reader :last_value
+  attr_reader :last_value, :store_active
 
   def call(env)
     RequestStore.store[:foo] ||= 0
     RequestStore.store[:foo] += 1
     @last_value = RequestStore.store[:foo]
+    @store_active = RequestStore.active?
     raise 'FAIL' if env[:error]
   end
 end


### PR DESCRIPTION
Add `RequestStore.active?` to determine if your code is running within the context of a request. This allows code that can be called from multiple entry points (request, background job, etc) to determine if a request store is available to be used (and guaranteed to be cleaned up when the calling context completes in the case of a request).