### PR TITLE
Make compatible with Rails streaming

### DIFF
--- a/lib/request_store/middleware.rb
+++ b/lib/request_store/middleware.rb
@@ -1,3 +1,12 @@
+require 'rack/body_proxy'
+
+# A middleware that ensures the RequestStore stays around until
+# the last part of the body is rendered. This is useful when
+# using streaming.
+#
+# Uses Rack::BodyProxy, adapted from Rack::Lock's usage of the
+# same pattern.
+
 module RequestStore
   class Middleware
     def initialize(app)
@@ -6,10 +15,18 @@ module RequestStore
 
     def call(env)
       RequestStore.begin!
-      @app.call(env)
+
+      response = @app.call(env)
+
+      returned = response << Rack::BodyProxy.new(response.pop) do
+        RequestStore.end!
+        RequestStore.clear!
+      end
     ensure
-      RequestStore.end!
-      RequestStore.clear!
+      unless returned
+        RequestStore.end!
+        RequestStore.clear!
+      end
     end
   end
 end

--- a/request_store.gemspec
+++ b/request_store.gemspec
@@ -18,6 +18,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
+  gem.add_dependency "rack", ">= 1.4"
+
   gem.add_development_dependency "rake", "~> 10.5"
   gem.add_development_dependency "minitest", "~> 5.0"
 end

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -25,7 +25,7 @@ class MiddlewareTest < Minitest::Test
 
   def test_middleware_resets_store_on_error
     e = assert_raises RuntimeError do
-      call_middleware error: true
+      call_middleware({:error => true})
     end
 
     assert_equal 'FAIL', e.message
@@ -45,7 +45,7 @@ class MiddlewareTest < Minitest::Test
 
   def test_middleware_ends_store_on_error
     assert_raises RuntimeError do
-      call_middleware error: true
+      call_middleware({:error => true})
     end
 
     assert_equal false, RequestStore.active?

--- a/test/middleware_test.rb
+++ b/test/middleware_test.rb
@@ -9,8 +9,15 @@ class MiddlewareTest < Minitest::Test
     @middleware = RequestStore::Middleware.new(@app)
   end
 
+  def call_middleware(opts = {})
+    _, _, proxy = @middleware.call(opts)
+    proxy.close
+  end
+
   def test_middleware_resets_store
-    2.times { @middleware.call({}) }
+    2.times do
+      call_middleware
+    end
 
     assert_equal 1, @app.last_value
     assert_equal({}, RequestStore.store)
@@ -18,7 +25,7 @@ class MiddlewareTest < Minitest::Test
 
   def test_middleware_resets_store_on_error
     e = assert_raises RuntimeError do
-      @middleware.call({:error => true})
+      call_middleware error: true
     end
 
     assert_equal 'FAIL', e.message
@@ -26,20 +33,33 @@ class MiddlewareTest < Minitest::Test
   end
 
   def test_middleware_begins_store
-    @middleware.call({})
+    call_middleware
     assert_equal true, @app.store_active
   end
 
   def test_middleware_ends_store
-    @middleware.call({})
+    call_middleware
+
     assert_equal false, RequestStore.active?
   end
 
   def test_middleware_ends_store_on_error
     assert_raises RuntimeError do
-      @middleware.call({:error => true})
+      call_middleware error: true
     end
 
     assert_equal false, RequestStore.active?
+  end
+
+  def test_middleware_stores_until_proxy_closes
+    _, _, proxy = @middleware.call({})
+
+    assert_equal 1, @app.last_value
+    assert RequestStore.active?
+
+    proxy.close
+
+    refute RequestStore.active?
+    refute RequestStore.store[:foo]
   end
 end

--- a/test/request_store_test.rb
+++ b/test/request_store_test.rb
@@ -7,6 +7,10 @@ class RequestStoreTest < Minitest::Test
     RequestStore.clear!
   end
 
+  def teardown
+    RequestStore.clear!
+  end
+
   def test_initial_state
     Thread.current[:request_store] = nil
     assert_equal RequestStore.store, Hash.new

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,5 +7,7 @@ class RackApp
     @last_value = RequestStore.store[:foo]
     @store_active = RequestStore.active?
     raise 'FAIL' if env[:error]
+
+    [200, {}, ["response"]]
   end
 end


### PR DESCRIPTION
When rendering a view with `render stream: true` the middleware clears the request store prematurely. This is because the request is considered complete shortly after the controller returns and not when all of the view fragments have been rendered. By wrapping the response in a `Rack::BodyProxy`, the middleware will instead clear out the request store after all of the streamed view is rendered and the body is complete.

I'm not sure if this is a common enough use case to accommodate in this gem, but I thought it might be useful to have the discussion, as well as help anyone else who may be seeing this behavior.
