### PR TITLE
Allow loading the store object

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: ruby
 sudo: false
 rvm:
-  - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
   - 2.1.0
   - 2.2.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
   - jruby-18mode
   - jruby-19mode
   - ruby-head
   - jruby-head
-  - ree
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -7,6 +7,10 @@ module RequestStore
     Thread.current[:request_store] ||= {}
   end
 
+  def self.store=(store)
+    Thread.current[:request_store] = store
+  end
+
   def self.clear!
     Thread.current[:request_store] = {}
   end

--- a/test/request_store_test.rb
+++ b/test/request_store_test.rb
@@ -20,6 +20,13 @@ class RequestStoreTest < Minitest::Test
     assert_equal Hash.new, RequestStore.store
   end
 
+  def test_assign_store
+    store_obj = { test_key: 'test' }
+    RequestStore.store = store_obj
+    assert_equal 'test', RequestStore.store[:test_key]
+    assert_equal store_obj, RequestStore.store
+  end
+
   def test_clear
     RequestStore.store[:foo] = 1
     RequestStore.clear!


### PR DESCRIPTION
Allow Loading store hash, This is useful for sharing the store keys between web services (requests) and background jobs (for instance delayed jobs)