### PR TITLE
GitHub is HTTPS by default

### DIFF
--- a/request_store.gemspec
+++ b/request_store.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["steve@steveklabnik.com"]
   gem.description   = %q{RequestStore gives you per-request global storage.}
   gem.summary       = %q{RequestStore gives you per-request global storage.}
-  gem.homepage      = "http://github.com/steveklabnik/request_store"
+  gem.homepage      = "https://github.com/steveklabnik/request_store"
   gem.licenses      = ["MIT"]
 
   gem.files         = `git ls-files`.split($/)


### PR DESCRIPTION
This reduces unnecessary redirection from http://... to https://... when someone visits this gem's homepage via https://rubygems.org/gems/request_store or some tools or APIs that use the gem's metadata.