### PR TITLE
Fix fatal crash when a mutable const is returned by the app

### DIFF
--- a/lib/request_store/middleware.rb
+++ b/lib/request_store/middleware.rb
@@ -16,12 +16,15 @@ module RequestStore
     def call(env)
       RequestStore.begin!
 
-      response = @app.call(env)
+      status, headers, body = @app.call(env)
+      returned = true
 
-      returned = response << Rack::BodyProxy.new(response.pop) do
+      body = Rack::BodyProxy.new(body) do
         RequestStore.end!
         RequestStore.clear!
       end
+
+      [status, headers, body]
     ensure
       unless returned
         RequestStore.end!

--- a/lib/request_store/middleware.rb
+++ b/lib/request_store/middleware.rb
@@ -17,12 +17,13 @@ module RequestStore
       RequestStore.begin!
 
       status, headers, body = @app.call(env)
-      returned = true
 
       body = Rack::BodyProxy.new(body) do
         RequestStore.end!
         RequestStore.clear!
       end
+      
+      returned = true
 
       [status, headers, body]
     ensure

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,3 +11,19 @@ class RackApp
     [200, {}, ["response"]]
   end
 end
+
+class RackAppWithConstResponse
+  RESPONSE = [200, {}, ["response"]]
+
+  attr_reader :last_value, :store_active
+
+  def call(env)
+    RequestStore.store[:foo] ||= 0
+    RequestStore.store[:foo] += 1
+    @last_value = RequestStore.store[:foo]
+    @store_active = RequestStore.active?
+    raise 'FAIL' if env[:error]
+
+    RESPONSE
+  end
+end


### PR DESCRIPTION
If an app using RequestStore returns a mutable constant, it gets mutated by RequestStore. This can cause errors as the object can keep growing larger and eventually crash. The fix is to not mutate the response body but instead return a new `Rack::BodyProxy` object.