### PR TITLE
Add new rubies to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ rvm:
   - 2.4.9
   - 2.5.7
   - 2.6.5
+  - 2.7.5
+  - 3.0.3
+  - 3.1.0
   - jruby-18mode
   - jruby-19mode
   - ruby-head


### PR DESCRIPTION
Hi, the latest Ruby version is **3.1**. This pull request adds 2.7, 3.0, and 3.1 to the CI matrix.