### PR TITLE
Drop unused directive 'executables' from gemspec

### DIFF
--- a/request_store.gemspec
+++ b/request_store.gemspec
@@ -14,7 +14,6 @@ Gem::Specification.new do |gem|
   gem.licenses      = ["MIT"]
 
   gem.files         = `git ls-files`.split($/)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 


### PR DESCRIPTION
This gem exposes no executables.