### PR TITLE
CI: add Ruby 3.2 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           - 2.7
           - '3.0'
           - 3.1
+          - 3.2
           - ruby-head
           - jruby-9.1
           - jruby-9.2

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,13 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in request_store.gemspec
 gemspec
+
+case Gem::Version.new(RUBY_VERSION.dup)
+when ->(ruby_version) { ruby_version >= Gem::Version.new('2.2.0') }
+  gem 'rake', '~> 13'
+when ->(ruby_version) { ruby_version >= Gem::Version.new('2.0.0') }
+  gem 'rake', '~> 12'
+else
+  gem 'rake', '~> 11'
+end
+

--- a/request_store.gemspec
+++ b/request_store.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency "rack", ">= 1.4"
 
-  gem.add_development_dependency "rake", "~> 10.5"
+  gem.add_development_dependency "rake"
   gem.add_development_dependency "minitest", "~> 5.0"
 end


### PR DESCRIPTION
Ruby 3.2 has [been released](https://www.ruby-lang.org/en/news/2022/12/25/ruby-3-2-0-released/)! Let's add it to the CI build matrix and ensure the project is compatible.