### PR TITLE
Use fiber storage if available for

### DIFF
--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -3,28 +3,38 @@ require "request_store/middleware"
 require "request_store/railtie" if defined?(Rails::Railtie)
 
 module RequestStore
+  if Fiber.respond_to?(:[])
+    def self.scope
+      Fiber
+    end
+  else
+    def self.scope
+      Thread.current
+    end
+  end
+
   def self.store
-    Thread.current[:request_store] ||= {}
+    scope[:request_store] ||= {}
   end
 
   def self.store=(store)
-    Thread.current[:request_store] = store
+    scope[:request_store] = store
   end
 
   def self.clear!
-    Thread.current[:request_store] = {}
+    scope[:request_store] = {}
   end
 
   def self.begin!
-    Thread.current[:request_store_active] = true
+    scope[:request_store_active] = true
   end
 
   def self.end!
-    Thread.current[:request_store_active] = false
+    scope[:request_store_active] = false
   end
 
   def self.active?
-    Thread.current[:request_store_active] || false
+    scope[:request_store_active] || false
   end
 
   def self.read(key)

--- a/test/request_store_test.rb
+++ b/test/request_store_test.rb
@@ -63,9 +63,9 @@ class RequestStoreTest < Minitest::Test
     assert_equal 4, RequestStore.delete(:foo) { 2 + 2 }
   end
 
-  def test_delegates_to_thread
+  def test_delegates_to_scope
     RequestStore.store[:foo] = 1
-    assert_equal 1, Thread.current[:request_store][:foo]
+    assert_equal 1, RequestStore.scope[:request_store][:foo]
   end
 
   def test_active_state


### PR DESCRIPTION
RequestStore uses fiber-local storage, so it doesn’t get passed down into child fibers (or threads). When using the fiber scheduler, request state can be lost when creating child fibers. Fiber storage is inherited by child fibers, and so using it avoids the problem. In every other way, it behaves like fiber locals.

Similar to https://github.com/BMorearty/request_store-fibers in theory.

cc @BMorearty