### PR TITLE
Fiber concurrency fix

### DIFF
--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -3,9 +3,20 @@ require "request_store/middleware"
 require "request_store/railtie" if defined?(Rails::Railtie)
 
 module RequestStore
-  if Fiber.respond_to?(:[])
+  if ::Fiber.respond_to?(:[])
+    class ::Fiber
+      def [](key)
+        (@local_storage || {})[key]
+      end
+
+      def []=(key, value)
+        @local_storage ||= {}
+        @local_storage[key] = value
+      end
+    end
+
     def self.scope
-      Fiber
+      ::Fiber.current
     end
   else
     def self.scope

--- a/lib/request_store/version.rb
+++ b/lib/request_store/version.rb
@@ -1,3 +1,3 @@
 module RequestStore
-  VERSION = "1.6.0"
+  VERSION = "1.6.1"
 end

--- a/test/request_store_test.rb
+++ b/test/request_store_test.rb
@@ -1,6 +1,6 @@
 require 'minitest/autorun'
 
-require 'request_store'
+require_relative '../lib/request_store'
 
 class RequestStoreTest < Minitest::Test
   def setup
@@ -76,5 +76,17 @@ class RequestStoreTest < Minitest::Test
 
     RequestStore.end!
     assert_equal false, RequestStore.active?
+  end
+
+  def test_concurrent_scopes
+    thread1_scope_id = nil
+    thread2_scope_id = nil
+    thread1 = Thread.new { thread1_scope_id = RequestStore.scope.object_id }
+    thread2 = Thread.new { thread2_scope_id = RequestStore.scope.object_id }
+    thread1.join
+    thread2.join
+
+    assert thread1_scope_id != thread2_scope_id,
+           'concurrent scopes should be different'
   end
 end


### PR DESCRIPTION
when using concurrent fibers/threads+fibers, the `Fiber` object is a global klass; this automatically causes data races and all kinds of bugs to show up in any app that uses 1.6.0

since the intention is for the gem to work with fibers, the best way to fulfill that intention is to patch the Fiber class such that each instance has local storage