### PR TITLE
Release 1.7.0 -- no longer use Fiber - reverts Fiber changes in release 1.6.0

### DIFF
--- a/lib/request_store.rb
+++ b/lib/request_store.rb
@@ -3,38 +3,28 @@ require "request_store/middleware"
 require "request_store/railtie" if defined?(Rails::Railtie)
 
 module RequestStore
-  if Fiber.respond_to?(:[])
-    def self.scope
-      Fiber
-    end
-  else
-    def self.scope
-      Thread.current
-    end
-  end
-
   def self.store
-    scope[:request_store] ||= {}
+    Thread.current[:request_store] ||= {}
   end
 
   def self.store=(store)
-    scope[:request_store] = store
+    Thread.current[:request_store] = store
   end
 
   def self.clear!
-    scope[:request_store] = {}
+    Thread.current[:request_store] = {}
   end
 
   def self.begin!
-    scope[:request_store_active] = true
+    Thread.current[:request_store_active] = true
   end
 
   def self.end!
-    scope[:request_store_active] = false
+    Thread.current[:request_store_active] = false
   end
 
   def self.active?
-    scope[:request_store_active] || false
+    Thread.current[:request_store_active] || false
   end
 
   def self.read(key)

--- a/lib/request_store/version.rb
+++ b/lib/request_store/version.rb
@@ -1,3 +1,3 @@
 module RequestStore
-  VERSION = "1.6.0"
+  VERSION = "1.7.0"
 end

--- a/test/request_store_test.rb
+++ b/test/request_store_test.rb
@@ -63,9 +63,9 @@ class RequestStoreTest < Minitest::Test
     assert_equal 4, RequestStore.delete(:foo) { 2 + 2 }
   end
 
-  def test_delegates_to_scope
+  def test_delegates_to_thread
     RequestStore.store[:foo] = 1
-    assert_equal 1, RequestStore.scope[:request_store][:foo]
+    assert_equal 1, Thread.current[:request_store][:foo]
   end
 
   def test_active_state


### PR DESCRIPTION
Fixes https://github.com/steveklabnik/request_store/issues/96 and Fixes #98 

Unless a Fiber is initialized with `Fiber.new(storage: nil)` then there is cross Fiber pollution of the RequestStore if the RequestStore is initialized or used in any parent Fiber. 

### Notes
1.6.0 added a method `RequestStore.scope` -- I was tempted to keep the method in 1.7.0 but decided to remove it for two reasons even though it is a breaking change.
   * We want 1.7.0 to have the same functionality as 1.5.x 
   * Whenever we want to use Fiber in a 2.x.x, I suspect we will want a different API than `RequestStore.scope` 